### PR TITLE
Basic Gerrit Support

### DIFF
--- a/weblate/trans/tests/test_vcs.py
+++ b/weblate/trans/tests/test_vcs.py
@@ -19,7 +19,7 @@
 #
 
 from weblate.trans.tests.test_models import RepoTestCase
-from weblate.trans.vcs import GitRepository, HgRepository, RepositoryException
+from weblate.trans.vcs import GitRepository, HgRepository, RepositoryException, GitWithGerritRepository
 
 import tempfile
 import shutil
@@ -226,6 +226,12 @@ class VCSGitTest(RepoTestCase):
             self.repo.configure_branch,
             'branch'
         )
+
+
+class VCSGerritTest(VCSGitTest):
+    _class = GitWithGerritRepository
+    _vcs = 'git'
+    _branch = 'default'
 
 
 class VCSHgTest(VCSGitTest):

--- a/weblate/trans/tests/test_vcs.py
+++ b/weblate/trans/tests/test_vcs.py
@@ -19,7 +19,8 @@
 #
 
 from weblate.trans.tests.test_models import RepoTestCase
-from weblate.trans.vcs import GitRepository, HgRepository, RepositoryException, GitWithGerritRepository
+from weblate.trans.vcs import GitRepository, HgRepository, \
+    RepositoryException, GitWithGerritRepository
 
 import tempfile
 import shutil
@@ -231,7 +232,7 @@ class VCSGitTest(RepoTestCase):
 class VCSGerritTest(VCSGitTest):
     _class = GitWithGerritRepository
     _vcs = 'git'
-    _branch = 'default'
+    _branch = 'master'
 
 
 class VCSHgTest(VCSGitTest):

--- a/weblate/trans/vcs.py
+++ b/weblate/trans/vcs.py
@@ -607,6 +607,21 @@ class GitRepository(Repository):
 
 
 @register_vcs
+class GitWithGerritRepository(GitRepository):
+
+    name = 'Gerrit'
+
+    def push(self, branch):
+        try:
+            self.execute(['review'])
+        except RepositoryException as error:
+            if error.retcode == 1:
+                # Nothing to push
+                return
+            raise
+
+
+@register_vcs
 class HgRepository(Repository):
     """
     Repository implementation for Mercurial.


### PR DESCRIPTION
Gerrit is a very popular Code Review Tool. It is a git under the hood but uses a specific review command instead of pushes.

To make use of it, the repository needs to contain a .gitreview file as defined at https://pypi.python.org/pypi/git-review#gitreview-file-format

I am rather unsure about the tests, since Gerrit is just with a different push workflow, I just added a class overriding the `VCSGitTest` that basically does the same as the Git Tests but uses a different push method.