### PR TITLE
allow creating new languages when using Java Property files

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,7 @@ weblate 2.3
 Released on ? 2015.
 
 * Dropped support for Django 1.6 and South migrations.
+* Support for adding new translations when using Java Property files
 
 weblate 2.2
 -----------

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -122,7 +122,9 @@ Java properties
 
 Native Java format for translations.
 
-Java properties are usually used as bilingual.
+Java properties are usually used as monolingual.
+
+This format supports creating new languages. When a new languages is created, a new empty file will be added to the repository. Only keys that are defined will be written to the newly created file. The WebLate maintainer needs to make sure that this is the expected behaviour with the framework in use.
 
 .. seealso::
 

--- a/weblate/trans/formats.py
+++ b/weblate/trans/formats.py
@@ -792,6 +792,21 @@ class PropertiesUtf8Format(FileFormat):
     loader = ('properties', 'javautf8file')
     monolingual = True
 
+    @classmethod
+    def supports_new_language(cls):
+        '''
+        Checks whether we can create new language file.
+        '''
+        return True
+
+    @staticmethod
+    def add_language(filename, code, base):
+        '''
+        Adds new language file.
+        '''
+        with open(filename, 'w') as output:
+            output.write('\n')
+
 
 @register_fileformat
 class PropertiesFormat(PropertiesUtf8Format):

--- a/weblate/trans/formats.py
+++ b/weblate/trans/formats.py
@@ -786,11 +786,18 @@ class StringsUtf8Format(FileFormat):
 
 
 @register_fileformat
-class PropertiesFormat(FileFormat):
+class PropertiesUtf8Format(FileFormat):
+    name = _('Java Properties (UTF-8)')
+    format_id = 'properties-utf8'
+    loader = ('properties', 'javautf8file')
+    monolingual = True
+
+
+@register_fileformat
+class PropertiesFormat(PropertiesUtf8Format):
     name = _('Java Properties')
     format_id = 'properties'
     loader = ('properties', 'javafile')
-    monolingual = True
 
     @classmethod
     def fixup(cls, store):
@@ -800,14 +807,6 @@ class PropertiesFormat(FileFormat):
         '''
         store.encoding = 'iso-8859-1'
         return store
-
-
-@register_fileformat
-class PropertiesUtf8Format(FileFormat):
-    name = _('Java Properties (UTF-8)')
-    format_id = 'properties-utf8'
-    loader = ('properties', 'javautf8file')
-    monolingual = True
 
 
 @register_fileformat

--- a/weblate/trans/tests/data/swing.properties
+++ b/weblate/trans/tests/data/swing.properties
@@ -1,0 +1,13 @@
+IGNORE=Ignore
+IGNOREALL=Ignore All
+ADD=Add to Dictionary
+REPLACE=Change
+REPLACEALL=Change All
+CANCEL=Cancel
+SUGGESTIONS=Suggestions
+INVALIDWORD=Not in Dictionary
+COMPLETED=Spellcheck completed.
+ADDWORD_1=Add
+ADDWORD_2=to dictionary?
+ADDWORD_3=Add Word?
+

--- a/weblate/trans/tests/test_formats.py
+++ b/weblate/trans/tests/test_formats.py
@@ -23,11 +23,12 @@ File format specific behavior.
 import tempfile
 from unittest import TestCase
 from weblate.trans.formats import (
-    AutoFormat, PoFormat, AndroidFormat,
+    AutoFormat, PoFormat, AndroidFormat, PropertiesFormat,
 )
 from weblate.trans.tests.utils import get_test_file
 
 TEST_PO = get_test_file('cs.po')
+TEST_PROPERTIES = get_test_file('swing.properties')
 TEST_ANDROID = get_test_file('strings.xml')
 TEST_POT = get_test_file('hello.pot')
 
@@ -42,6 +43,8 @@ class AutoFormatTest(TestCase):
     MATCH = 'msgid_plural'
     MASK = 'po/*.po'
     EXPECTED_PATH = 'po/cs_CZ.po'
+    FIND = u'Hello, world!\n'
+    MATCH = u'Ahoj světe!\n'
 
     def test_parse(self):
         storage = self.FORMAT(self.FILE)
@@ -51,12 +54,12 @@ class AutoFormatTest(TestCase):
 
     def test_find(self):
         storage = self.FORMAT(self.FILE)
-        unit, add = storage.find_unit('', 'Hello, world!\n')
+        unit, add = storage.find_unit('', self.FIND)
         self.assertFalse(add)
         if self.COUNT == 0:
             self.assertTrue(unit is None)
         else:
-            self.assertEqual(unit.get_target(), u'Ahoj světe!\n')
+            self.assertEqual(unit.get_target(), self.MATCH)
 
     def test_add(self):
         if self.FORMAT.supports_new_language():
@@ -78,6 +81,18 @@ class AutoFormatTest(TestCase):
 
 class PoFormatTest(AutoFormatTest):
     FORMAT = PoFormat
+
+
+class PropertiesFormatTest(AutoFormatTest):
+    FORMAT = PropertiesFormat
+    FILE = TEST_PROPERTIES
+    MIME = 'text/plain'
+    COUNT = 12
+    EXT = 'properties'
+    MASK = 'java/swing_messages_*.properties'
+    EXPECTED_PATH = 'java/swing_messages_cs_CZ.properties'
+    FIND = 'IGNORE'
+    MATCH = 'Ignore'
 
 
 class AndroidFormatTest(AutoFormatTest):


### PR DESCRIPTION
It's as simple as this. The repository maintainer needs to make sure, that the framework in use is using fallback to some base language, but that is a very common behaviour with Java Frameworks