### PR TITLE
Add permission to save template (source) translation

### DIFF
--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -625,6 +625,7 @@ def create_groups(update):
             Permission.objects.get(codename='upload_translation'),
             Permission.objects.get(codename='overwrite_translation'),
             Permission.objects.get(codename='save_translation'),
+            Permission.objects.get(codename='save_template'),
             Permission.objects.get(codename='accept_suggestion'),
             Permission.objects.get(codename='delete_suggestion'),
             Permission.objects.get(codename='vote_suggestion'),

--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -651,6 +651,7 @@ def create_groups(update):
             Permission.objects.get(codename='push_translation'),
             Permission.objects.get(codename='automatic_translation'),
             Permission.objects.get(codename='save_translation'),
+            Permission.objects.get(codename='save_template'),
             Permission.objects.get(codename='accept_suggestion'),
             Permission.objects.get(codename='vote_suggestion'),
             Permission.objects.get(codename='override_suggestion'),

--- a/weblate/html/last-changes.html
+++ b/weblate/html/last-changes.html
@@ -28,7 +28,13 @@
 {% if c.target %}
 <tr>
 <td colspan="4">{% format_translation c.target c.unit.translation.language %}</td>
-<td>{% if perms.trans.save_translation and c.unit and c.target != c.unit.target %}<a class="historybutton small-button" href="{{ c.translation.get_translate_url}}?{% if search_id %}sid={{ search_id }}&amp;offset={{ offset }}&amp;{% endif %}checksum={{ c.unit.checksum }}&amp;revert={{ c.id }}" title="{% trans "Revert to this translation" %}">{% trans "Revert" %}</a>{% endif %}</td>
+<td>
+{% if perms.trans.save_translation and c.unit and c.target != c.unit.target %}
+{% if perms.trans.save_template or not trans.is_template %}
+<a class="historybutton small-button" href="{{ c.translation.get_translate_url}}?{% if search_id %}sid={{ search_id }}&amp;offset={{ offset }}&amp;{% endif %}checksum={{ c.unit.checksum }}&amp;revert={{ c.id }}" title="{% trans "Revert to this translation" %}">{% trans "Revert" %}</a>
+{% endif %}
+{% endif %}
+</td>
 </tr>
 {% endif %}
 {% empty %}

--- a/weblate/html/translate.html
+++ b/weblate/html/translate.html
@@ -189,12 +189,14 @@
 <button type="submit" class="btn btn-danger btn-xs" name="downvote" value="{{ suggestion.id }}"><i class="fa fa-thumbs-down"></i> {% trans "Vote against" %}</button>
 {% endif %}
 {% if not unit.only_vote_suggestions or perms.trans.override_suggestion %}
+{% if perms.trans.save_template or not object.is_template %}
 {% if perms.trans.accept_suggestion %}
 <button type="submit" class="btn btn-success btn-xs" name="accept" value="{{ suggestion.id }}"><i class="fa fa-check"></i> {% trans "Accept" %}</button>
 <button type="submit" class="btn btn-warning btn-xs" name="accept_edit" value="{{ suggestion.id }}"><i class="fa fa-pencil"></i> {% trans "Accept and edit" %}</button>
 {% endif %}
 {% if perms.trans.delete_suggestion %}
 <button type="submit" class="btn btn-danger btn-xs" name="delete" value="{{ suggestion.id }}"><i class="fa fa-trash"></i> {% trans "Delete" %}</button>
+{% endif %}
 {% endif %}
 {% endif %}
 </div>

--- a/weblate/html/translate.html
+++ b/weblate/html/translate.html
@@ -18,7 +18,9 @@
 {% block content %}
 
 {% if perms.trans.save_translation %}
+{% if perms.trans.save_template or not object.is_template %}
 <a href="{% url 'zen' project=unit.translation.subproject.project.slug subproject=unit.translation.subproject.slug lang=unit.translation.language.code %}?sid={{ search_id }}" title="{% trans "Edit in Zen mode" %}" class="btn btn-default pull-right flip"><i class="fa fa-arrows-alt"></i> {% trans "Zen" %}</a>
+{% endif %}
 {% endif %}
 
 {% with unit.translation as object %}
@@ -79,7 +81,9 @@
   <div class="panel-footer">
     {% if not unit.only_vote_suggestions or perms.trans.override_suggestion %}
     {% if perms.trans.save_translation %}
+    {% if perms.trans.save_template or not object.is_template %}
     <input class="btn btn-default" type="submit" value="{% trans "Save" %}" name="save" tabindex="150" {% if locked %}disabled="disabled"{% endif %} />
+    {% endif %}
     {% else %}
     {% url 'login' as login_url %}
     {% with unit.translation.get_translate_url as translate_url %}
@@ -97,6 +101,7 @@
     {% endif %}
 
     {% if perms.trans.save_translation %}
+    {% if perms.trans.save_template or not object.is_template %}
     <div class="pull-right flip hidden-xs">
     {% trans "Commit message:" %} 
     <input type="text" name="commit_message" class="tooltip-control" 
@@ -107,6 +112,7 @@
         title="{% trans "You can leave this empty in most cases as Weblate generates basic commit messages automatically." %}"
     />
     </div>
+    {% endif %}
     {% endif %}
   </div>
 </div>
@@ -217,7 +223,9 @@
     <td>{% get_state_flags item %}</td>
     <td>
     {% if perms.trans.save_translation %}
+    {% if perms.trans.save_template or not object.is_template %}
     <a class="mergebutton small-button btn btn-default" href="{{ unit.translation.get_translate_url}}?sid={{ search_id }}&amp;offset={{ offset }}&amp;checksum={{ unit.checksum }}&amp;merge={{ item.id }}" title="{% trans "Use this translation for all subprojects" %}">{% trans "Use this translation" %}</a>
+    {% endif %}
     {% endif %}
     </td>
     </tr>
@@ -355,7 +363,9 @@
         <td class="target">{% format_translation item.target unit.translation.language simple=True %}</td>
         <td>
         {% if perms.trans.save_translation %}
+        {% if perms.trans.save_template or not object.is_template %}
         <a class="copydict btn btn-default btn-xs" title="{% trans "Copy word to translation" %}">{% trans "Copy" %}</a>
+        {% endif %}
         {% endif %}
         </td>
         </tr>

--- a/weblate/trans/migrations/0023_perm_save_template.py
+++ b/weblate/trans/migrations/0023_perm_save_template.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('trans', '0022_auto_20150309_0932'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='unit',
+            options={'ordering': ['priority', 'position'], 'permissions': (('save_translation', 'Can save translation'), ('save_template', 'Can save template'),)},
+        ),
+    ]

--- a/weblate/trans/models/unit.py
+++ b/weblate/trans/models/unit.py
@@ -312,6 +312,7 @@ class Unit(models.Model):
     class Meta(object):
         permissions = (
             ('save_translation', "Can save translation"),
+            ('save_template', "Can save template"),
         )
         ordering = ['priority', 'position']
         app_label = 'trans'

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -290,12 +290,13 @@ def handle_translate(translation, request, user_locked,
 
     if 'suggest' in request.POST:
         go_next = perform_suggestion(unit, form, request)
-    elif translation.is_template and not request.user.has_perm('trans.save_template'):
+    elif (translation.is_template() and not
+          request.user.has_perm('trans.save_template')):
         # Need privilege to save
         messages.error(
             request,
             _('You don\'t have privileges to save templates!')
-        )    
+        )
     elif not request.user.has_perm('trans.save_translation'):
         # Need privilege to save
         messages.error(
@@ -331,14 +332,15 @@ def handle_merge(translation, request, next_unit_url):
     '''
     Handles unit merging.
     '''
-    if translation.is_template and not request.user.has_perm('trans.save_template'):
+    if (translation.is_template() and not
+          request.user.has_perm('trans.save_template')):
         # Need privilege to save
         messages.error(
             request,
             _('You don\'t have privileges to save templates!')
         )
         return
-    
+
     if not request.user.has_perm('trans.save_translation'):
         # Need privilege to save
         messages.error(
@@ -380,14 +382,15 @@ def handle_merge(translation, request, next_unit_url):
 
 
 def handle_revert(translation, request, next_unit_url):
-    if translation.is_template and not request.user.has_perm('trans.save_template'):
+    if (translation.is_template() and not
+          request.user.has_perm('trans.save_template')):
         # Need privilege to save
         messages.error(
             request,
             _('You don\'t have privileges to save templates!')
         )
         return
-    
+
     if not request.user.has_perm('trans.save_translation'):
         # Need privilege to save
         messages.error(

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -333,7 +333,7 @@ def handle_merge(translation, request, next_unit_url):
     Handles unit merging.
     '''
     if (translation.is_template() and not
-       request.user.has_perm('trans.save_template')):
+            request.user.has_perm('trans.save_template')):
         # Need privilege to save
         messages.error(
             request,
@@ -383,7 +383,7 @@ def handle_merge(translation, request, next_unit_url):
 
 def handle_revert(translation, request, next_unit_url):
     if (translation.is_template() and not
-       request.user.has_perm('trans.save_template')):
+            request.user.has_perm('trans.save_template')):
         # Need privilege to save
         messages.error(
             request,

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -290,6 +290,12 @@ def handle_translate(translation, request, user_locked,
 
     if 'suggest' in request.POST:
         go_next = perform_suggestion(unit, form, request)
+    elif translation.is_template and not request.user.has_perm('trans.save_template'):
+        # Need privilege to save
+        messages.error(
+            request,
+            _('You don\'t have privileges to save templates!')
+        )    
     elif not request.user.has_perm('trans.save_translation'):
         # Need privilege to save
         messages.error(
@@ -325,6 +331,14 @@ def handle_merge(translation, request, next_unit_url):
     '''
     Handles unit merging.
     '''
+    if translation.is_template and not request.user.has_perm('trans.save_template'):
+        # Need privilege to save
+        messages.error(
+            request,
+            _('You don\'t have privileges to save templates!')
+        )
+        return
+    
     if not request.user.has_perm('trans.save_translation'):
         # Need privilege to save
         messages.error(
@@ -366,6 +380,14 @@ def handle_merge(translation, request, next_unit_url):
 
 
 def handle_revert(translation, request, next_unit_url):
+    if translation.is_template and not request.user.has_perm('trans.save_template'):
+        # Need privilege to save
+        messages.error(
+            request,
+            _('You don\'t have privileges to save templates!')
+        )
+        return
+    
     if not request.user.has_perm('trans.save_translation'):
         # Need privilege to save
         messages.error(

--- a/weblate/trans/views/edit.py
+++ b/weblate/trans/views/edit.py
@@ -333,7 +333,7 @@ def handle_merge(translation, request, next_unit_url):
     Handles unit merging.
     '''
     if (translation.is_template() and not
-          request.user.has_perm('trans.save_template')):
+       request.user.has_perm('trans.save_template')):
         # Need privilege to save
         messages.error(
             request,
@@ -383,7 +383,7 @@ def handle_merge(translation, request, next_unit_url):
 
 def handle_revert(translation, request, next_unit_url):
     if (translation.is_template() and not
-          request.user.has_perm('trans.save_template')):
+       request.user.has_perm('trans.save_template')):
         # Need privilege to save
         messages.error(
             request,
@@ -453,6 +453,14 @@ def handle_suggestions(translation, request, this_unit_url, next_unit_url):
                     _('You do not have privilege to accept suggestions!')
                 )
                 return HttpResponseRedirect(this_unit_url)
+            elif (translation.is_template() and not
+                  request.user.has_perm('trans.save_template')):
+                # Need privilege to save
+                messages.error(
+                    request,
+                    _('You don\'t have privileges to save templates!')
+                )
+                return HttpResponseRedirect(this_unit_url)
             suggestion.accept(translation, request)
             if 'accept' in request.POST:
                 redirect_url = next_unit_url
@@ -462,6 +470,14 @@ def handle_suggestions(translation, request, this_unit_url, next_unit_url):
                 messages.error(
                     request,
                     _('You do not have privilege to delete suggestions!')
+                )
+                return HttpResponseRedirect(this_unit_url)
+            elif (translation.is_template() and not
+                  request.user.has_perm('trans.save_template')):
+                # Need privilege to save
+                messages.error(
+                    request,
+                    _('You don\'t have privileges to save templates!')
                 )
                 return HttpResponseRedirect(this_unit_url)
             suggestion.delete()


### PR DESCRIPTION
In some cases it will be very helpful to let only managers save template (source) translations. Regular  users (external) should be able to contribute to all other languages only.
