### PR TITLE
Openshift

### DIFF
--- a/.openshift/action_hooks/pre_build_python
+++ b/.openshift/action_hooks/pre_build_python
@@ -19,12 +19,10 @@
 #
 
 # Don't let OpenShift install weblate and its dependencies directly as this leads to timeouts during gear creation and deploys
+export OPENSHIFT_PYTHON_REQUIREMENTS_PATH=no_such_file
+
 if [ -e $OPENSHIFT_REPO_DIR/setup.py ]; then
   mv $OPENSHIFT_REPO_DIR/setup.py $OPENSHIFT_REPO_DIR/setup_weblate.py
-fi
-
-if [ -e $OPENSHIFT_REPO_DIR/requirements.txt ]; then
-	mv $OPENSHIFT_REPO_DIR/requirements.txt $OPENSHIFT_REPO_DIR/requirements-mandatory.txt
 fi
 
 # Show install/update page, will be replaced with app by install.sh

--- a/openshift/install.sh
+++ b/openshift/install.sh
@@ -100,7 +100,7 @@ sh "python ${OPENSHIFT_REPO_DIR}/openshift/manage.py collectstatic --noinput"
 if [ ! -s $OPENSHIFT_DATA_DIR/.credentials ]; then
   echo "Generating Weblate admin credentials and writing them to ${OPENSHIFT_DATA_DIR}/.credentials"
   sh "python ${OPENSHIFT_REPO_DIR}/openshift/manage.py createadmin"
-  sh "python ${OPENSHIFT_REPO_DIR}/openshift/secure_db.py | tee ${OPENSHIFT_DATA_DIR}/.credentials"
+  DJANGO_SETTINGS_MODULE='weblate.settings_openshift' sh "python ${OPENSHIFT_REPO_DIR}/openshift/secure_db.py | tee ${OPENSHIFT_DATA_DIR}/.credentials"
 fi
 
 if find_script_dir; then

--- a/openshift/install.sh
+++ b/openshift/install.sh
@@ -51,19 +51,19 @@ source $OPENSHIFT_HOMEDIR/python/virtenv/bin/activate
 
 cd ${OPENSHIFT_REPO_DIR}
 
-sh "python ${OPENSHIFT_REPO_DIR}/setup_weblate.py develop"
-
 # Pin Django version to 1.7 to avoid surprises when 1.8 comes out.
-sed -e 's/Django[<>=]\+.*/Django>1.7,<1.8/' $OPENSHIFT_REPO_DIR/requirements-mandatory.txt >/tmp/requirements.txt
+sed -e 's/Django[<>=]\+.*/Django>1.7,<1.8/' $OPENSHIFT_REPO_DIR/requirements.txt >/tmp/requirements.txt
 
-sh "pip install -r /tmp/requirements.txt"
+sh "pip install -U -r /tmp/requirements.txt"
 
 # Install optional dependencies without failing if some can't be installed.
 while read line; do
-  if [[ $line != -r* ]]; then
+  if [[ $line != -r* ]] && [[ $line != \#* ]]; then
     sh "pip install $line" || true
   fi
 done < $OPENSHIFT_REPO_DIR/requirements-optional.txt
+
+sh "python ${OPENSHIFT_REPO_DIR}/setup_weblate.py develop"
 
 if [ ! -s $OPENSHIFT_DATA_DIR/weblate.db ]; then
   rm -f ${OPENSHIFT_DATA_DIR}/.credentials

--- a/openshift/install.sh
+++ b/openshift/install.sh
@@ -51,8 +51,8 @@ source $OPENSHIFT_HOMEDIR/python/virtenv/bin/activate
 
 cd ${OPENSHIFT_REPO_DIR}
 
-# Pin Django version to 1.7 to avoid surprises when 1.8 comes out.
-sed -e 's/Django[<>=]\+.*/Django>1.7,<1.8/' $OPENSHIFT_REPO_DIR/requirements.txt >/tmp/requirements.txt
+# Pin Django version to 1.8 to avoid surprises when 1.9 comes out.
+sed -e 's/Django[<>=]\+.*/Django>=1.8,<1.9/' $OPENSHIFT_REPO_DIR/requirements.txt >/tmp/requirements.txt
 
 sh "pip install -U -r /tmp/requirements.txt"
 

--- a/openshift/secure_db.py
+++ b/openshift/secure_db.py
@@ -21,6 +21,9 @@
 
 from django.conf import settings
 
+# Django must be configured before imports, or some will fail with ImproperlyConfigured exception.
+settings.configure()
+
 import os
 import sqlite3
 from openshift.openshiftlibs import make_secure_key, get_openshift_secret_token
@@ -29,9 +32,6 @@ from django.contrib.auth.hashers import make_password
 
 
 def secure_db():
-    # Use default Django settings
-    settings.configure()
-
     new_pass = make_secure_key({
         'hash': sha256(get_openshift_secret_token()).hexdigest(),
         'original': '0' * 12,

--- a/openshift/secure_db.py
+++ b/openshift/secure_db.py
@@ -19,11 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from django.conf import settings
-
-# Django must be configured before imports, or some will fail with ImproperlyConfigured exception.
-settings.configure()
-
 import os
 import sqlite3
 from openshift.openshiftlibs import make_secure_key, get_openshift_secret_token

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 #pyuca
-https://github.com/SmileyChris/pyuca/archive/master.zip
+git+https://github.com/SmileyChris/pyuca@555292b
 pyLibravatar
 pydns
 babel

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,9 @@ setup(
     download_url='https://github.com/nijel/weblate',
     author='Michal Čihař',
     author_email='michal@cihar.com',
-    dependency_links = ['git+https://github.com/SmileyChris/pyuca@555292b#egg=pyuca-1.0'],
+    dependency_links=[
+        'git+https://github.com/SmileyChris/pyuca@555292b#egg=pyuca-1.0',
+    ],
     install_requires=REQUIRES,
     extras_require={
         'Mercurial': ['Mercurial>=2.8'],

--- a/setup.py
+++ b/setup.py
@@ -94,12 +94,11 @@ setup(
     download_url='https://github.com/nijel/weblate',
     author='Michal Čihař',
     author_email='michal@cihar.com',
+    dependency_links = ['git+https://github.com/SmileyChris/pyuca@555292b#egg=pyuca-1.0'],
     install_requires=REQUIRES,
     extras_require={
         'Mercurial': ['Mercurial>=2.8'],
-        'Unicode': [
-            'https://github.com/SmileyChris/pyuca/archive/master.zip'
-        ],
+        'Unicode': ['pyuca==1.0'],
         'Avatars': ['pyLibravatar', 'pydns'],
         'Android': ['babel'],
     },


### PR DESCRIPTION
Hi Michal

Since commit 7ba24ec Weblate can no longer be installed on OpenShift. This pull request contains the necessary adjustments to the OpenShift configuration to fix this. Some explanations:
As far as I can see setuptools doesn't support URLs in extra_requires. The `dependency_links` settings must be used instead. Because the version given in extra_requires must match the one in `setup.py` behind the given URL (currently still 1.0), I pinned the git commit to the current HEAD of the master branch of pyuca. Also see: https://pythonhosted.org/setuptools/setuptools.html#dependencies-that-aren-t-in-pypi
The other commit fixes the generation of the admin password on OpenShift which was broken (but didn't abort the installation) since commit 5758d22. 

Kind regards
  Daniel
