### PR TITLE
Solution for issue #709: Openshift and static files

### DIFF
--- a/openshift/htaccess
+++ b/openshift/htaccess
@@ -1,0 +1,3 @@
+RewriteEngine On
+RewriteCond %{REQUEST_URI} ^/(robots.txt|favicon.ico)$
+RewriteRule .* media%{REQUEST_URI} [L]

--- a/openshift/install.sh
+++ b/openshift/install.sh
@@ -115,4 +115,6 @@ gear stop
 ln -sf ../openshift/wsgi.py $OPENSHIFT_REPO_DIR/wsgi/application
 touch $OPENSHIFT_DATA_DIR/.installed
 
+ln -sf ../openshift/htaccess $OPENSHIFT_REPO_DIR/wsgi/.htaccess
+
 gear start


### PR DESCRIPTION
Hi Michal

Please note that the current master head doesn't install on OpenShift as the newly released python-social-auth 0.2.5 doesn't install. This doesn't seem to be related to OpenShift as I'm also unable to install python-social-auth 0.2.5 into a local virtualenv (IOError: [Errno 2] No such file or directory: 'social/tests/requirements.txt').

Kind regards
  Daniel
