### PR TITLE
Add GitHub VCS provider.

### DIFF
--- a/docs/admin/config.rst
+++ b/docs/admin/config.rst
@@ -190,6 +190,16 @@ GIT_ROOT
 Path where Weblate will store cloned VCS repositories. Defaults to
 :file:`repos` subdirectory.
 
+.. setting:: GITHUB_USERNAME
+
+GITHUB_USERNAME
+---------------
+
+GitHub username that will be used to send pull requests for translation
+updates.
+
+.. seealso:: :ref:`github-push`
+
 .. setting:: GOOGLE_ANALYTICS_ID
 
 GOOGLE_ANALYTICS_ID

--- a/docs/admin/continuous.rst
+++ b/docs/admin/continuous.rst
@@ -98,6 +98,19 @@ via the admin interface first, otherwise pushing will fail.
 .. seealso:: :ref:`private` for setting up SSH keys
 
 
+.. _github-push:
+
+Pushing changes to GitHub as pull request
++++++++++++++++++++++++++++++++++++++++++
+
+If you are translating a project that's hosted on GitHub and don't want to
+push translations to the repository, you can have them sent as a pull request instead.
+
+You need to configure the :guilabel:`hub` command line tool and set :setting:`GITHUB_USERNAME` for this to work.
+
+.. seealso:: :setting:`GITHUB_USERNAME`, :ref:`hub-setup` for configuration instructions
+
+
 .. _hosted-push:
 
 Pushing changes from Hosted Weblate

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -36,6 +36,8 @@ babel (optional for Android resources support)
     http://babel.pocoo.org/
 Database backend
     Any database supported in Django will work, check their documentation for more details.
+hub (optional for sending pull requests to GitHub)
+    https://hub.github.com/
 
 Requirements on Debian or Ubuntu
 ++++++++++++++++++++++++++++++++
@@ -93,6 +95,10 @@ you might need additional components:
     # Database option 3: postgresql
     apt-get install postgresql
 
+    # GitHub PR support: hub
+    # See https://hub.github.com/
+
+
 Requirements on openSUSE
 ++++++++++++++++++++++++
 
@@ -135,6 +141,9 @@ you might need additional components:
     # Database option 3: postgresql
     zypper install postgresql
 
+    # GitHub PR support: hub
+    # See https://hub.github.com/
+
 Requirements on OSX
 +++++++++++++++++++
 
@@ -145,7 +154,7 @@ your :file:`.bash_profile` file or executed somehow:
 
     export PYTHONPATH="/usr/local/lib/python2.7/site-packages:$PYTHONPATH"
 
-This configuration make available the installed libraries to python
+This configuration makes the installed libraries available to Python.
 
 
 Requirements using pip installer
@@ -234,8 +243,28 @@ When using MySQL, don't forget to create database with UTF-8 encoding:
     # Grant all privileges to  weblate user
     GRANT ALL PRIVILEGES ON weblate.* TO 'weblate'@'localhost'  IDENTIFIED BY 'password';
 
-    # Create database    
+    # Create database
     CREATE DATABASE weblate CHARACTER SET utf8;
+
+.. _hub-setup:
+
+Setting up hub
+++++++++++++++
+
+:ref:`github-push` requires a configured :guilabel:`hub` installation on
+your server. Follow the installation instructions at https://hub.github.com
+and perform an action with :guilabel:`hub` to finish the configuration,
+for example:
+
+.. code-block:: sh
+
+    hub clone octocat/Spoon-Knife
+
+:guilabel:`hub` will ask you for your GitHub credentials, retrieve a token and store it into :file:`~/.config/hub`.
+
+.. note::
+
+    Use the username you configured :guilabel:`hub` with as :setting:`GITHUB_USERNAME`.
 
 .. _installation:
 

--- a/weblate/appsettings.py
+++ b/weblate/appsettings.py
@@ -194,6 +194,9 @@ ENABLE_HTTPS = getvalue('ENABLE_HTTPS', False)
 # Hiding repository credentials
 HIDE_REPO_CREDENTIALS = getvalue('HIDE_REPO_CREDENTIALS', True)
 
+# GitHub username for sending pull requests
+GITHUB_USERNAME = getvalue('GITHUB_USERNAME', None)
+
 # Whiteboard
 ENABLE_WHITEBOARD = getvalue('ENABLE_WHITEBOARD', False)
 

--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -177,6 +177,10 @@ TEMPLATE_LOADERS = (
     )),
 )
 
+# GitHub username for sending pull requests.
+# Please see the documentation for more details.
+GITHUB_USERNAME = None
+
 # Authentication configuration
 AUTHENTICATION_BACKENDS = (
     'social.backends.email.EmailAuth',

--- a/weblate/trans/vcs.py
+++ b/weblate/trans/vcs.py
@@ -33,6 +33,7 @@ from distutils.version import LooseVersion
 from dateutil import parser
 from weblate.trans.util import get_clean_env, add_configuration_error
 from weblate.trans.ssh import ssh_file, SSH_WRAPPER
+from weblate import appsettings
 
 VCS_REGISTRY = {}
 VCS_CHOICES = []
@@ -636,19 +637,7 @@ class GithubRepository(GitRepository):
     name = 'GitHub'
 
     _cmd = 'hub'
-    _hub_config_file = os.path.join(os.path.expanduser('~'),
-                                    '.config/hub')
-    _hub_user_prefix = '- user: '
-
-    _hub_user = None
-    if 'GITHUB_USER' in os.environ:
-        _hub_user = os.environ['GITHUB_USER']
-    elif os.path.isfile(_hub_config_file):
-        with open(_hub_config_file) as config_file:
-            for line in config_file.read().splitlines():
-                if line.startswith(_hub_user_prefix):
-                    _hub_user = line[len(_hub_user_prefix):]
-                    break
+    _hub_user = appsettings.GITHUB_USERNAME
 
     if _hub_user is None:
         _is_supported = False


### PR DESCRIPTION
Tries to fix #656. Uses the [`hub`](https://github.com/github/hub) command line tool and requires that is has been set up (either by creating `~/.config/hub` or setting `GITHUB_USERNAME` and `GITHUB_PASSWORD` environment variables). The most complicated part is probably getting the Github username configured for hub out of the config, which is needed because it's also the name of the remote created for the fork (`hub fork`). Maybe there's an easier way?

I thought about using a Github API module for Python instead of `hub`, but this would probably require some admin functions to manage Github API tokens.. using `hub` should be simpler.

I didn't test this too much (and didn't yet add any automated tests), but wanted to get some feedback.. so let me know what you think!

You can see an example pull request at https://github.com/fwalch/neovim/pull/11.