### PR TITLE
Openshift: do not change existing groups on update

### DIFF
--- a/docs/admin/management.rst
+++ b/docs/admin/management.rst
@@ -270,7 +270,7 @@ setupgroups
 Configures default groups and (if called with ``--move``) assigns all users
 to default group.
 
-The option ``--no-update`` disables update of existing groups (only adds
+The option ``--no-privs-update`` disables update of existing groups (only adds
 new ones).
 
 .. seealso:: :ref:`privileges`
@@ -306,5 +306,3 @@ Fetches remote VCS repositories and updates internal cache.
 
 You can either define which project or component to update (eg.
 ``weblate/master``) or use ``--all`` to update all existing components.
-
-

--- a/openshift/install.sh
+++ b/openshift/install.sh
@@ -81,7 +81,11 @@ fi
 
 sh "python ${OPENSHIFT_REPO_DIR}/openshift/manage.py migrate --noinput"
 
-sh "python ${OPENSHIFT_REPO_DIR}/openshift/manage.py setupgroups --move"
+if [ ! -s $OPENSHIFT_DATA_DIR/.credentials ]; then
+  sh "python ${OPENSHIFT_REPO_DIR}/openshift/manage.py setupgroups --move"
+else
+  sh "python ${OPENSHIFT_REPO_DIR}/openshift/manage.py setupgroups --no-privs-update"
+fi
 
 sh "python ${OPENSHIFT_REPO_DIR}/openshift/manage.py setuplang"
 


### PR DESCRIPTION
This patch prevents updating existing user groups when running an update on Openshift. This preserves any changes made to the default group. Of course this means the administrator might need to manually assign new permissions to the default group, but I think that makes some sense.

I have also included a fix to the documentation regarding the `setupgroups --no-privs-update` option which of course could be applied separately.