### PR TITLE
Checks can be disabled by default

### DIFF
--- a/weblate/trans/checks/base.py
+++ b/weblate/trans/checks/base.py
@@ -32,17 +32,22 @@ class Check(object):
     target = False
     source = False
     ignore_untranslated = True
+    default_disabled = False
     severity = 'info'
 
     def __init__(self):
         id_dash = self.check_id.replace('_', '-')
         self.doc_id = 'check-%s' % id_dash
+        self.enable_string = id_dash
         self.ignore_string = 'ignore-%s' % id_dash
 
     def check_target(self, sources, targets, unit):
         '''
         Checks target strings.
         '''
+        # Is this disabled by default
+        if self.default_disabled and not self.enable_string in unit.all_flags:
+            return False
         # Is this check ignored
         if self.ignore_string in unit.all_flags:
             return False

--- a/weblate/trans/checks/format.py
+++ b/weblate/trans/checks/format.py
@@ -105,16 +105,13 @@ class BaseFormatCheck(TargetCheck):
     '''
     flag = None
     regexp = None
+    default_disabled = True
     severity = 'danger'
 
     def check_target_unit(self, sources, targets, unit):
         '''
         Checks single unit, handling plurals.
         '''
-        # Verify unit is properly flagged
-        if self.flag not in unit.all_flags:
-            return False
-
         # Special case languages with single plural form
         if len(sources) > 1 and len(targets) == 1:
             return self.check_format(

--- a/weblate/trans/checks/format.py
+++ b/weblate/trans/checks/format.py
@@ -103,7 +103,6 @@ class BaseFormatCheck(TargetCheck):
     '''
     Base class for fomat string checks.
     '''
-    flag = None
     regexp = None
     default_disabled = True
     severity = 'danger'
@@ -222,7 +221,6 @@ class PythonFormatCheck(BaseFormatCheck):
     check_id = 'python_format'
     name = _('Python format')
     description = _('Format string does not match source')
-    flag = 'python-format'
     regexp = PYTHON_PRINTF_MATCH
 
     def is_position_based(self, string):
@@ -236,7 +234,6 @@ class PHPFormatCheck(BaseFormatCheck):
     check_id = 'php_format'
     name = _('PHP format')
     description = _('Format string does not match source')
-    flag = 'php-format'
     regexp = PHP_PRINTF_MATCH
 
     def is_position_based(self, string):
@@ -250,7 +247,6 @@ class CFormatCheck(BaseFormatCheck):
     check_id = 'c_format'
     name = _('C format')
     description = _('Format string does not match source')
-    flag = 'c-format'
     regexp = C_PRINTF_MATCH
 
     def is_position_based(self, string):
@@ -264,7 +260,6 @@ class PythonBraceFormatCheck(BaseFormatCheck):
     check_id = 'python_brace_format'
     name = _('Python brace format')
     description = _('Format string does not match source')
-    flag = 'python-brace-format'
     regexp = PYTHON_BRACE_MATCH
 
     def is_position_based(self, string):

--- a/weblate/trans/validators.py
+++ b/weblate/trans/validators.py
@@ -21,14 +21,10 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _, ugettext_lazy
 from weblate.trans.checks import CHECKS
 
+EXTRA_FLAGS = {v.enable_string: v.name for k, v in CHECKS.iteritems() \
+    if v.default_disabled}
 
-EXTRA_FLAGS = {
-    'rst-text': ugettext_lazy('RST text'),
-    'python-format': ugettext_lazy('Python format string'),
-    'c-format': ugettext_lazy('C format string'),
-    'php-format': ugettext_lazy('PHP format string'),
-    'python-brace-format': ugettext_lazy('Python brace format string'),
-}
+EXTRA_FLAGS['rst-text'] = ugettext_lazy('RST text')
 
 IGNORE_CHECK_FLAGS = set([CHECKS[x].ignore_string for x in CHECKS])
 


### PR DESCRIPTION
Adds a `default_disabled` field to the `Check` class which can be set to disable a check by default. This generalizes the current implementation for the format checks and allows custom checks that are disabled by default but can be explicitly enabled using the proper flag.

This can be used in custom checks as follows:

```
class FooCheck(TargetCheck):

    check_id = 'foo'
    name = _('Foo check')
    description = _('Your translation is foo')
    default_disabled = True

    # Real check code
    def check_single(self, source, target, unit, cache_slot):
        return 'foo' in target
```

If this checks gets included it will not be run by default, but one can explicitly set the `foo` tag for a unit. The existing checks in weblate/trans/checks/format.py have been migrated to use this new functionality.

I will write some tests for my own use using this functionality and if the tests have a wider use I will provide pull requests for them, too.