### PR TITLE
Fix typo: "can not" => "cannot"

### DIFF
--- a/weblate/accounts/views.py
+++ b/weblate/accounts/views.py
@@ -128,7 +128,7 @@ def deny_demo(request):
     """
     messages.warning(
         request,
-        _('You can not change demo account on the demo server.')
+        _('You cannot change demo account on the demo server.')
     )
     return redirect('profile')
 


### PR DESCRIPTION
- Noticed when doing enUS to enGB on Weblate of the Weblate software (how meta...).
- "Can not" here looked weird to me.
- Technically, "can not" is valid, but "cannot" is used more frequently and "can not" with the space is generally used when not able to be a contraction like "can't". In this case, use the version without the space because "You can't change demo account on the demo server" is valid.

(It's worth noting here that I don't know if I've changed it in the right place for it to be included in the translatable strings as well as the code when it gets updated, but I hope so and we'll see!)