### PR TITLE
Make the "language missing" sentence flow a bit more nicely

### DIFF
--- a/weblate/html/subproject.html
+++ b/weblate/html/subproject.html
@@ -102,7 +102,7 @@
 <p>{% trans "Project maintainers will get notified about this request and will add the language manually." %}</p>
 {% endif %}
 {{ new_lang_form|crispy }}
-<p class="help-block"><a href="{% url 'contact' %}?subject=New+language+request+for+{{ object }}">{% trans "Can not find your language in above list?" %}</a></p>
+<p class="help-block"><a href="{% url 'contact' %}?subject=New+language+request+for+{{ object }}">{% trans "Can't find your language in the list above?" %}</a></p>
 </div>
 <div class="panel-footer">
 {% if object.new_lang == 'contact' %}


### PR DESCRIPTION
- Contract "can not" to "can't" and rearrange "above list" to be "the list above".
  To me at least, this reads better.

Thanks very much for making Weblate! I particularly like the version control integration that pushes changes as correctly attributed commits. (Sorry about all these tiny wording changes.)