### PR TITLE
Make urls in comments clickable

### DIFF
--- a/weblate/html/list-comments.html
+++ b/weblate/html/list-comments.html
@@ -25,6 +25,6 @@
 <div class="clearfix"></div>
 {% endif %}
 <div class="list-group">
-<div class="list-group-item" dir="auto">{{ comment.comment }}</div>
+<div class="list-group-item" dir="auto">{{ comment.comment|urlize }}</div>
 </div>
 {% endfor %}


### PR DESCRIPTION
We often leave links to documentation or screenshots during discussion with translators in the comments.

This makes those links clickable so they don't have to be copy-pasted anymore.