### PR TITLE
Include static folder in .egg

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -27,6 +27,7 @@ recursive-include locale *.mo
 include weblate/trans/tests/data/*
 include weblate/trans/widget-images/*.png
 include weblate/lang/plurals.txt
+recursive-include weblate/static *
 exclude weblate/settings.py
 prune docs/_build
 global-exclude *.swp *.swo


### PR DESCRIPTION
When installing the current git repo as a built package I ran into the exception `UncompressableFileError while rendering: 'bootstrap/css/bootstrap.css' could not be found in the COMPRESS_ROOT '...' or with staticfiles.`

This fixes it. (related: #605)