### PR TITLE
OSX strings utf-16 format

### DIFF
--- a/weblate/trans/formats.py
+++ b/weblate/trans/formats.py
@@ -933,7 +933,7 @@ class StringsUtf8Format(FileFormat):
 
 
 @register_dialect
-class DialectStringsUtf8(DialectStrings):
+class DialectStringsUtf16(DialectStrings):
     name = "strings-utf16"
     default_encoding = "utf-16"
 
@@ -960,7 +960,7 @@ class StringsUtf16Format(FileFormat):
 
 
 @register_fileformat
-class PropertiesUtf16Format(FileFormat):
+class PropertiesUtf8Format(FileFormat):
     name = _('Java Properties (UTF-8)')
     format_id = 'properties-utf8'
     loader = ('properties', 'javautf8file')

--- a/weblate/trans/formats.py
+++ b/weblate/trans/formats.py
@@ -932,6 +932,26 @@ class StringsUtf8Format(FileFormat):
     new_translation = '\n'
 
 
+class stringsutf16file(propfile):
+    Name = "OS X Strings (UTF-16)"
+    Extensions = ['strings']
+
+    def __init__(self, *args, **kwargs):
+        kwargs['personality'] = "strings-utf16"
+        kwargs['encoding'] = "utf-16"
+        super(stringsutf16file, self).__init__(*args, **kwargs)
+
+
+@register_fileformat
+class StringsUtf16Format(FileFormat):
+    name = _('OS X Strings (UTF-16)')
+    format_id = 'strings-utf16'
+    new_translation = '\n'
+
+    @classmethod
+    def get_class(cls):
+        return stringsutf16file
+
 @register_fileformat
 class PropertiesUtf8Format(FileFormat):
     name = _('Java Properties (UTF-8)')

--- a/weblate/trans/formats.py
+++ b/weblate/trans/formats.py
@@ -22,7 +22,7 @@ File format specific behavior.
 '''
 from django.utils.translation import ugettext_lazy as _
 from translate.storage.lisa import LISAfile
-from translate.storage.properties import propunit, propfile
+from translate.storage.properties import propunit, propfile, register_dialect, DialectStrings
 from translate.storage.xliff import xliffunit, xlifffile
 from translate.storage.po import pounit, pofile
 from translate.storage.php import phpunit
@@ -930,6 +930,12 @@ class StringsUtf8Format(FileFormat):
     format_id = 'strings-utf8'
     loader = ('properties', 'stringsutf8file')
     new_translation = '\n'
+
+
+@register_dialect
+class DialectStringsUtf8(DialectStrings):
+    name = "strings-utf16"
+    default_encoding = "utf-16"
 
 
 class stringsutf16file(propfile):

--- a/weblate/trans/formats.py
+++ b/weblate/trans/formats.py
@@ -958,8 +958,9 @@ class StringsUtf16Format(FileFormat):
     def get_class(cls):
         return stringsutf16file
 
+
 @register_fileformat
-class PropertiesUtf8Format(FileFormat):
+class PropertiesUtf16Format(FileFormat):
     name = _('Java Properties (UTF-8)')
     format_id = 'properties-utf8'
     loader = ('properties', 'javautf8file')


### PR DESCRIPTION
As outlined at https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html, apple recommends to use UTF-16 for *.strings files