### PR TITLE
Fix static file path in nginx configuration file

### DIFF
--- a/examples/weblate.nginx.conf
+++ b/examples/weblate.nginx.conf
@@ -4,17 +4,17 @@ server {
 	root /path/to/weblate/weblate;
 
 	location /favicon.ico {
-		alias /path/to/weblate/data/static/favicon.ico;
+		alias /path/to/weblate/weblate/static/favicon.ico;
 		expires 30d;
 	}
 
 	location /robots.txt {
-		alias /path/to/weblate/data/static/robots.txt;
+		alias /path/to/weblate/weblate/static/robots.txt;
 		expires 30d;
 	}
 
 	location /static {
-		alias /path/to/weblate/data/static/;
+		alias /path/to/weblate/weblate/static/;
 		expires 30d;
 	}
 


### PR DESCRIPTION
There's no folder named ```static``` under the ```data``` directory.