### PR TITLE
Skip migration for profile without email address

### DIFF
--- a/weblate/accounts/models.py
+++ b/weblate/accounts/models.py
@@ -717,7 +717,8 @@ def post_login_handler(sender, request, user, **kwargs):
 
     # Migrate django-registration based verification to python-social-auth
     if (user.has_usable_password() and
-            not user.social_auth.filter(provider='email').exists()):
+            not user.social_auth.filter(provider='email').exists() and
+            user.email):
         social = user.social_auth.create(
             provider='email',
             uid=user.email,


### PR DESCRIPTION
## Desired situation

Using Weblate with a custom auth backend that doesn't provide email addresses.

## Current problem

The first user ever can login just fine. The second user triggers a crash during the login process:

```python
Internal Server Error: /cas/login/
Traceback (most recent call last):
  File "virtual/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "virtual/local/lib/python2.7/site-packages/cas_consumer/views.py", line 49, in login
    auth_login(request, user)
  File "virtual/local/lib/python2.7/site-packages/django/contrib/auth/__init__.py", line 103, in login
    user_logged_in.send(sender=user.__class__, request=request, user=user)
  File "virtual/local/lib/python2.7/site-packages/django/dispatch/dispatcher.py", line 198, in send
    response = receiver(signal=self, sender=sender, **named)
  File "virtual/local/lib/python2.7/site-packages/weblate/accounts/models.py", line 708, in post_login_handler
    uid=user.email,
...
  File "virtual/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 65, in execute
    return self.cursor.execute(sql, params)
IntegrityError: duplicate key value violates unique constraint "social_auth_usersocialauth_provider_2f763109e2c4a1fb_uniq"
DETAIL:  Key (provider, uid)=(email, ) already exists.
```