### PR TITLE
Remove duplicate groups from list_display

### DIFF
--- a/weblate/accounts/admin.py
+++ b/weblate/accounts/admin.py
@@ -52,7 +52,6 @@ class WeblateUserAdmin(UserAdmin):
     active.
     '''
     list_display = UserAdmin.list_display + ('is_active', 'user_groups', 'id')
-    list_filter = UserAdmin.list_filter + ('groups',)
 
     def user_groups(self, obj):
         """


### PR DESCRIPTION
Since [Django 1.5](https://github.com/django/django/commit/69ff1b7390e140f332a5aa55c44a091c838923fb) `groups` is part of `UserAdmin`'s `list_display` - the filter now shows up twice in the admin.