### PR TITLE
Additional flag to check max-length

### DIFF
--- a/docs/user/checks.rst
+++ b/docs/user/checks.rst
@@ -142,6 +142,22 @@ when the original string was using that as well.
 
 .. seealso:: https://en.wikipedia.org/wiki/Ellipsis
 
+.. _check-max-length:
+
+Maximum Length
+~~~~~~~~~~~~~~
+
+Translation is too long to accept. This only checks for the length of translation
+characters.
+
+Source and translation usually do not have same amount of characters, but if 
+translation is too long, it can be affect a rendered shape. For example, in some UI
+widget, it should be kept in a specific length of characters in order to show
+complete translation within limited space.
+
+Unlike the other checks, the flag should be set as a ``key:value`` pair like
+``max-length:100``.
+
 .. _check-python-format:
 .. _check-python-brace-format:
 .. _check-php-format:

--- a/weblate/trans/checks/base.py
+++ b/weblate/trans/checks/base.py
@@ -33,6 +33,7 @@ class Check(object):
     ignore_untranslated = True
     default_disabled = False
     severity = 'info'
+    enable_check_value = False
 
     def __init__(self):
         id_dash = self.check_id.replace('_', '-')
@@ -44,6 +45,10 @@ class Check(object):
         '''
         Checks target strings.
         '''
+        if self.enable_check_value:
+            return self.check_target_unit_with_flag(
+                sources, targets, unit
+            )
         # Is this disabled by default
         if self.default_disabled and self.enable_string not in unit.all_flags:
             return False
@@ -54,6 +59,12 @@ class Check(object):
         if self.ignore_untranslated and not unit.translated:
             return False
         return self.check_target_unit(sources, targets, unit)
+
+    def check_target_unit_with_flag(self, sources, targets, unit):
+        '''
+        Checks flag value
+        '''
+        raise NotImplementedError()
 
     def check_target_unit(self, sources, targets, unit):
         '''
@@ -128,6 +139,12 @@ class TargetCheck(Check):
     '''
     target = True
 
+    def check_target_unit_with_flag(self, sources, targets, unit):
+        '''
+        We don't check flag value here.
+        '''
+        return False
+
     def check_source(self, source, unit):
         '''
         We don't check source strings here.
@@ -147,6 +164,12 @@ class SourceCheck(Check):
     '''
     source = True
 
+    def check_target_unit_with_flag(self, sources, targets, unit):
+        '''
+        We don't check flag value here.
+        '''
+        return False
+
     def check_single(self, source, target, unit):
         '''
         We don't check target strings here.
@@ -158,6 +181,33 @@ class SourceCheck(Check):
         Checks source string
         '''
         raise NotImplementedError()
+
+
+class TargetCheckWithFlag(Check):
+    '''
+    Basic class for target checks with flag value.
+    '''
+    default_disabled = True
+    enable_check_value = True
+    target = True
+
+    def check_target_unit_with_flag(self, sources, targets, unit):
+        '''
+        Checks flag value
+        '''
+        raise NotImplementedError()
+
+    def check_single(self, source, target, unit):
+        '''
+        We don't check single phrase here.
+        '''
+        return False
+
+    def check_source(self, source, unit):
+        '''
+        We don't check source strings here.
+        '''
+        return False
 
 
 class CountingCheck(TargetCheck):

--- a/weblate/trans/validators.py
+++ b/weblate/trans/validators.py
@@ -101,6 +101,7 @@ def validate_check_flags(val):
     if not val:
         return
     for flag in val.split(','):
-        if flag in EXTRA_FLAGS or flag in IGNORE_CHECK_FLAGS:
+        name = flag.split(':')[0]
+        if name in EXTRA_FLAGS or name in IGNORE_CHECK_FLAGS:
             continue
         raise ValidationError(_('Invalid check flag: "%s"') % flag)


### PR DESCRIPTION
This patch is about handling 'maximum length' of translation which discussed in #864.
However, I am afraid that I got the point exactly and my approach is not graceful to implement initial version. Although basic function works, more exception handling is required.

To enable checking 'max-length', the follow steps are required.
 1. add 'weblate.trans.checks.chars.MaxLengthCheck' to CHECK_LIST variable at settings.py
 2. choose 'Maximum Length of Translation' to Check flags of "source / review " UI
 3. then edit value like "max-length:5"

@nijel, could you review my patch and advise me?

