### PR TITLE
Add a setting TRANSLATE_PUBLIC that hides access to translations 

### DIFF
--- a/weblate/appsettings.py
+++ b/weblate/appsettings.py
@@ -232,6 +232,7 @@ DEFAULT_COMMITER_EMAIL = getvalue(
 DEFAULT_COMMITER_NAME = getvalue(
     'DEFAULT_COMMITER_NAME', 'Weblate'
 )
+TRANSLATE_PUBLIC=getvalue('TRANSLATE_PUBLIC',True)
 
 # Obsolete configs, needed for data migration
 GIT_ROOT = getvalue('GIT_ROOT', os.path.join(BASE_DIR, 'repos'))

--- a/weblate/html/base.html
+++ b/weblate/html/base.html
@@ -82,6 +82,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="wl-navbar-main">
       <ul class="nav navbar-nav">
+        {% if user.is_authenticated or translate_public %}
         <li><a href="{% url 'home' %}">{% trans "Dashboard" %}</a></li>
         {% if usertranslations %}
         <li class="dropdown">
@@ -101,6 +102,7 @@
             {% endfor %}
           </ul>
         </li>
+        {% endif %}
         <li><a href="{% documentation 'index' %}">{% trans "Documentation" %}</a></li>
       </ul>
       <ul class="nav navbar-nav navbar-right flip">

--- a/weblate/html/index.html
+++ b/weblate/html/index.html
@@ -16,6 +16,7 @@
 </p>
 {% endif %}
 
+{% if user.is_authenticated or translate_public %}
 {% if whiteboard_enabled %}
 {% for msg in whiteboard_messages %}
 {% show_message 'info whiteboard' msg.message %}
@@ -164,5 +165,5 @@
 </div>
 
 </div>
-
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
Add a setting TRANSLATE_PUBLIC that hides access to translations if not connected (when TRANSLATE_PUBLIC==False)

No changes by default.

It's a little hacky for now because it only hide the main page and the menu. (so if you have the urls to the projects, you'll be able to see them)

So just a proposal, waiting something more consistent that works with permissions