### PR TITLE
Correct syntax variant Spanish

### DIFF
--- a/weblate/html/i18n.html
+++ b/weblate/html/i18n.html
@@ -24,7 +24,6 @@ for l in Language.objects.exclude(name__contains='generated').values_list('name'
 {% trans "Angika" %}
 {% trans "Arabic" %}
 {% trans "Aragonese" %}
-{% trans "Argentinean Spanish" %}
 {% trans "Armenian" %}
 {% trans "Assamese" %}
 {% trans "Asturian" %}
@@ -173,6 +172,7 @@ for l in Language.objects.exclude(name__contains='generated').values_list('name'
 {% trans "Songhai languages" %}
 {% trans "Sotho" %}
 {% trans "Spanish" %}
+{% trans "Spanish (Argentina)" %}
 {% trans "Sundanese" %}
 {% trans "Swahili" %}
 {% trans "Swedish" %}


### PR DESCRIPTION
The phrase "Argentinean Spanish" is misspelled. Should be "Spanish (Argentina)" because it is a variant of the Spanish language.