### PR TITLE
Fix Openshift install not pinning Django to 1.8

### DIFF
--- a/openshift/install.sh
+++ b/openshift/install.sh
@@ -52,10 +52,12 @@ source $OPENSHIFT_HOMEDIR/python/virtenv/bin/activate
 cd ${OPENSHIFT_REPO_DIR}
 
 # Pin Django version to 1.8 to avoid surprises when 1.9 comes out.
-sed -e 's/Django[<>=]\+.*/Django>=1.8,<1.9/' $OPENSHIFT_REPO_DIR/requirements.txt >/tmp/requirements.txt
-
-# Prevent lxml 3.5 or later to be used on OpenShift because its compilation needs more memory than small gears can provide.
-sed -e 's/lxml[<>=]\+.*/\0,<3.5/' $OPENSHIFT_REPO_DIR/requirements.txt >/tmp/requirements.txt
+# Prevent lxml 3.5 or later to be used on OpenShift because its compilation
+# needs more memory than small gears can provide.
+cat $OPENSHIFT_REPO_DIR/requirements.txt |
+  sed -e 's/Django[<>=]\+.*/Django>=1.8,<1.9/' |
+  sed -e 's/lxml[<>=]\+.*/\0,<3.5/' \
+  >/tmp/requirements.txt
 
 sh "pip install -U -r /tmp/requirements.txt"
 


### PR DESCRIPTION
This broke with commit 8ddd4b92ec97af3fa14ec9ec2cd83a0eddefce3f since that commit did run sed again on the original requirements.txt, ignoring the previous sed.

The `cat` I added is not necessary, but it reads nicer IMHO. And if somebody wants to add another transformation rules it's easy to understand and do