### PR TITLE
Openshift optimize install

### DIFF
--- a/openshift/install.sh
+++ b/openshift/install.sh
@@ -49,6 +49,10 @@ touch $OPENSHIFT_DATA_DIR/.install
 export PYTHONUNBUFFERED=1
 source $OPENSHIFT_HOMEDIR/python/virtenv/bin/activate
 
+# Stop unneeded cartridges to save memory
+gear stop --cart cron
+gear stop --cart mysql
+
 cd ${OPENSHIFT_REPO_DIR}
 
 # Pin Django version to 1.8 to avoid surprises when 1.9 comes out.
@@ -67,6 +71,9 @@ while read line; do
     sh "pip install $line" || true
   fi
 done < $OPENSHIFT_REPO_DIR/requirements-optional.txt
+
+# Start the database again as it is needed for setup scripts
+gear start --cart mysql
 
 sh "python ${OPENSHIFT_REPO_DIR}/setup_weblate.py develop"
 

--- a/openshift/install.sh
+++ b/openshift/install.sh
@@ -111,7 +111,7 @@ if find_script_dir; then
   ln -sf ${OPENSHIFT_REPO_DIR}/openshift/settings.sh $SCRIPT_DIR/settings
 fi
 
-gear stop
+gear stop --cart python
 
 # Link sources below $OPENSHIFT_REPO_DIR must be relative or they will be invalid after restore/clone operations
 ln -sf ../openshift/wsgi.py $OPENSHIFT_REPO_DIR/wsgi/application

--- a/openshift/install.sh
+++ b/openshift/install.sh
@@ -78,7 +78,6 @@ gear start --cart mysql
 sh "python ${OPENSHIFT_REPO_DIR}/setup_weblate.py develop"
 
 sh "python ${OPENSHIFT_REPO_DIR}/openshift/manage.py migrate --noinput"
-sh "python ${OPENSHIFT_REPO_DIR}/openshift/manage.py collectstatic --noinput"
 
 if [ ! -s $OPENSHIFT_DATA_DIR/.credentials ]; then
   sh "python ${OPENSHIFT_REPO_DIR}/openshift/manage.py changesite --set-name ${OPENSHIFT_APP_DNS}"


### PR DESCRIPTION
Even more changes to the Openshift deployment. When deploying on small gears, the deployment still can quickly run out of memory and this is another attempt to improve this. I wanted to keep this separate from #980 since theses fixes might need some discussion.

The changes:
* Before pip install stop both the mysql and the cron cartridges to free up resources. Keep the python cartridge running, so Weblate can display the update message
* Restart mysql for the execution of the management commands
* For restarting only stop the python cartridge, but keep mysql running. As the mysql cartridge can take quite some time to restart this reduces the full downtime of the system (where openshift reports just a 503 due to weblate not running)
* In addition the duplicate call to collectstatic was removed. I hope this was not intentional, but it looks ok to me ;)
