### PR TITLE
Angularjs interpolation check

### DIFF
--- a/weblate/appsettings.py
+++ b/weblate/appsettings.py
@@ -130,6 +130,7 @@ CHECK_LIST = getvalue('CHECK_LIST', (
     'weblate.trans.checks.format.PHPFormatCheck',
     'weblate.trans.checks.format.CFormatCheck',
     'weblate.trans.checks.format.JavascriptFormatCheck',
+    'weblate.trans.checks.angularjs.AngularJSInterpolationCheck',
     'weblate.trans.checks.consistency.PluralsCheck',
     'weblate.trans.checks.consistency.ConsistencyCheck',
     'weblate.trans.checks.chars.NewlineCountingCheck',

--- a/weblate/trans/checks/angularjs.py
+++ b/weblate/trans/checks/angularjs.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2012 - 2015 Michal Čihař <michal@cihar.com>
+# Copyright © 2015 Philipp Wolfer <ph.wolfer@gmail.com>
+#
+# This file is part of Weblate <http://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from weblate.trans.checks.base import TargetCheck
+from django.utils.translation import ugettext_lazy as _
+import re
+
+ANGULARJS_INTERPOLATION_MATCH = re.compile(
+    r'''
+    {{              # start symbol
+        \s*         # ignore whitespace
+        (.+?)
+        \s*         # ignore whitespace
+    }}              # end symbol
+    ''',
+    re.VERBOSE
+)
+
+WHITESPACE = re.compile(r'\s+')
+
+
+class AngularJSInterpolationCheck(TargetCheck):
+    '''
+    Check for AngularJS interpolation string
+    '''
+    check_id = 'angularjs'
+    name = _('Mismatched AngularJS interpolation strings')
+    description = _('AngularJS interpolation strings do not match source')
+    severity = 'danger'
+
+    def check_single(self, source, target, unit, cache_slot):
+        # Try geting source parsing from cache
+        src_match = self.get_cache(unit, cache_slot)
+
+        # Cache miss
+        if src_match is None:
+            src_match = ANGULARJS_INTERPOLATION_MATCH.findall(source)
+            self.set_cache(unit, src_match, cache_slot)
+        # Any interpolation strings in source?
+        if len(src_match) == 0:
+            return False
+        # Parse target
+        tgt_match = ANGULARJS_INTERPOLATION_MATCH.findall(target)
+        if len(src_match) != len(tgt_match):
+            return True
+
+        # Remove whitespace
+        src_tags = set([re.sub(WHITESPACE, '', x) for x in src_match])
+        tgt_tags = set([re.sub(WHITESPACE, '', x) for x in tgt_match])
+
+        return src_tags != tgt_tags

--- a/weblate/trans/checks/angularjs.py
+++ b/weblate/trans/checks/angularjs.py
@@ -48,10 +48,6 @@ class AngularJSInterpolationCheck(TargetCheck):
     severity = 'danger'
 
     def check_single(self, source, target, unit):
-        # Verify unit is properly flagged
-        if self.enable_string not in unit.all_flags:
-            return False
-
         src_match = ANGULARJS_INTERPOLATION_MATCH.findall(source)
 
         # Any interpolation strings in source?

--- a/weblate/trans/checks/angularjs.py
+++ b/weblate/trans/checks/angularjs.py
@@ -41,12 +41,17 @@ class AngularJSInterpolationCheck(TargetCheck):
     '''
     Check for AngularJS interpolation string
     '''
-    check_id = 'angularjs'
-    name = _('Mismatched AngularJS interpolation strings')
+    check_id = 'angularjs_interpolate'
+    name = _('AngularJS interpolation string')
     description = _('AngularJS interpolation strings do not match source')
     severity = 'danger'
+    flag = 'angularjs-interpolate'
 
     def check_single(self, source, target, unit, cache_slot):
+        # Verify unit is properly flagged
+        if self.flag not in unit.all_flags:
+            return False
+
         # Try geting source parsing from cache
         src_match = self.get_cache(unit, cache_slot)
 

--- a/weblate/trans/checks/angularjs.py
+++ b/weblate/trans/checks/angularjs.py
@@ -19,9 +19,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from weblate.trans.checks.base import TargetCheck
-from django.utils.translation import ugettext_lazy as _
 import re
+from django.utils.translation import ugettext_lazy as _
+from weblate.trans.checks.base import TargetCheck
 
 ANGULARJS_INTERPOLATION_MATCH = re.compile(
     r'''

--- a/weblate/trans/checks/angularjs.py
+++ b/weblate/trans/checks/angularjs.py
@@ -47,23 +47,20 @@ class AngularJSInterpolationCheck(TargetCheck):
     default_disabled = True
     severity = 'danger'
 
-    def check_single(self, source, target, unit, cache_slot):
+    def check_single(self, source, target, unit):
         # Verify unit is properly flagged
         if self.enable_string not in unit.all_flags:
             return False
 
-        # Try geting source parsing from cache
-        src_match = self.get_cache(unit, cache_slot)
+        src_match = ANGULARJS_INTERPOLATION_MATCH.findall(source)
 
-        # Cache miss
-        if src_match is None:
-            src_match = ANGULARJS_INTERPOLATION_MATCH.findall(source)
-            self.set_cache(unit, src_match, cache_slot)
         # Any interpolation strings in source?
         if len(src_match) == 0:
             return False
-        # Parse target
+
         tgt_match = ANGULARJS_INTERPOLATION_MATCH.findall(target)
+
+        # Fail the check if the number of matches is different
         if len(src_match) != len(tgt_match):
             return True
 

--- a/weblate/trans/checks/angularjs.py
+++ b/weblate/trans/checks/angularjs.py
@@ -41,11 +41,11 @@ class AngularJSInterpolationCheck(TargetCheck):
     '''
     Check for AngularJS interpolation string
     '''
-    check_id = 'angularjs_interpolate'
+    check_id = 'angularjs_format'
     name = _('AngularJS interpolation string')
     description = _('AngularJS interpolation strings do not match source')
     severity = 'danger'
-    flag = 'angularjs-interpolate'
+    flag = 'angularjs-format'
 
     def check_single(self, source, target, unit, cache_slot):
         # Verify unit is properly flagged

--- a/weblate/trans/checks/angularjs.py
+++ b/weblate/trans/checks/angularjs.py
@@ -44,12 +44,12 @@ class AngularJSInterpolationCheck(TargetCheck):
     check_id = 'angularjs_format'
     name = _('AngularJS interpolation string')
     description = _('AngularJS interpolation strings do not match source')
+    default_disabled = True
     severity = 'danger'
-    flag = 'angularjs-format'
 
     def check_single(self, source, target, unit, cache_slot):
         # Verify unit is properly flagged
-        if self.flag not in unit.all_flags:
+        if self.enable_string not in unit.all_flags:
             return False
 
         # Try geting source parsing from cache

--- a/weblate/trans/tests/test_angularjs_checks.py
+++ b/weblate/trans/tests/test_angularjs_checks.py
@@ -36,7 +36,7 @@ class AngularJSInterpolationCheckTest(TestCase):
         self.assertFalse(self.check.check_single(
             'strins',
             'string',
-            MockUnit('angularjs_no_format'),
+            MockUnit('angularjs_no_format', flags='angularjs-format'),
             0
         ))
 
@@ -44,7 +44,7 @@ class AngularJSInterpolationCheckTest(TestCase):
         self.assertFalse(self.check.check_single(
             u'{{name}} string {{other}}',
             u'{{name}} {{other}} string',
-            MockUnit('angularjs_format'),
+            MockUnit('angularjs_format', flags='angularjs-format'),
             0
         ))
 
@@ -52,7 +52,7 @@ class AngularJSInterpolationCheckTest(TestCase):
         self.assertFalse(self.check.check_single(
             u'{{name}} string {{other}}',
             u'{{other}} string {{name}}',
-            MockUnit('angularjs_format_ignore_position'),
+            MockUnit('angularjs_format_ignore_position', flags='angularjs-format'),
             0
         ))
 
@@ -60,7 +60,7 @@ class AngularJSInterpolationCheckTest(TestCase):
         self.assertFalse(self.check.check_single(
             u'{{ name   }} string',
             u'{{name}} string',
-            MockUnit('angularjs_different_whitespace'),
+            MockUnit('angularjs_different_whitespace', flags='angularjs-format'),
             0
         ))
 
@@ -68,14 +68,14 @@ class AngularJSInterpolationCheckTest(TestCase):
         self.assertTrue(self.check.check_single(
             u'{{name}} string',
             u'string',
-            MockUnit('angularjs_missing_format'),
+            MockUnit('angularjs_missing_format', flags='angularjs-format'),
             0
         ))
 
     def test_wrong_value(self):
         self.assertTrue(self.check.check_single(
             u'{{name}} string',
-            u'{{notname}} string',
-            MockUnit('angularjs_wrong_value'),
+            u'{{nameerror}} string',
+            MockUnit('angularjs_wrong_value', flags='angularjs-format'),
             0
         ))

--- a/weblate/trans/tests/test_angularjs_checks.py
+++ b/weblate/trans/tests/test_angularjs_checks.py
@@ -52,7 +52,9 @@ class AngularJSInterpolationCheckTest(TestCase):
         self.assertFalse(self.check.check_single(
             u'{{name}} string {{other}}',
             u'{{other}} string {{name}}',
-            MockUnit('angularjs_format_ignore_position', flags='angularjs-format'),
+            MockUnit(
+                'angularjs_format_ignore_position',
+                flags='angularjs-format'),
             0
         ))
 
@@ -60,7 +62,9 @@ class AngularJSInterpolationCheckTest(TestCase):
         self.assertFalse(self.check.check_single(
             u'{{ name   }} string',
             u'{{name}} string',
-            MockUnit('angularjs_different_whitespace', flags='angularjs-format'),
+            MockUnit(
+                'angularjs_different_whitespace',
+                flags='angularjs-format'),
             0
         ))
 

--- a/weblate/trans/tests/test_angularjs_checks.py
+++ b/weblate/trans/tests/test_angularjs_checks.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2012 - 2015 Michal Čihař <michal@cihar.com>
+# Copyright © 2015 Philipp Wolfer <ph.wolfer@gmail.com>
+#
+# This file is part of Weblate <http://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Tests for AngularJS checks.
+"""
+
+from unittest import TestCase
+from weblate.trans.checks.angularjs import AngularJSInterpolationCheck
+from weblate.trans.tests.test_checks import MockUnit
+
+
+class AngularJSInterpolationCheckTest(TestCase):
+    def setUp(self):
+        self.check = AngularJSInterpolationCheck()
+
+    def test_no_format(self):
+        self.assertFalse(self.check.check_single(
+            'strins',
+            'string',
+            MockUnit('angularjs_no_format'),
+            0
+        ))
+
+    def test_format(self):
+        self.assertFalse(self.check.check_single(
+            u'{{name}} string {{other}}',
+            u'{{name}} {{other}} string',
+            MockUnit('angularjs_format'),
+            0
+        ))
+
+    def test_format_ignore_position(self):
+        self.assertFalse(self.check.check_single(
+            u'{{name}} string {{other}}',
+            u'{{other}} string {{name}}',
+            MockUnit('angularjs_format_ignore_position'),
+            0
+        ))
+
+    def test_different_whitespace(self):
+        self.assertFalse(self.check.check_single(
+            u'{{ name   }} string',
+            u'{{name}} string',
+            MockUnit('angularjs_different_whitespace'),
+            0
+        ))
+
+    def test_missing_format(self):
+        self.assertTrue(self.check.check_single(
+            u'{{name}} string',
+            u'string',
+            MockUnit('angularjs_missing_format'),
+            0
+        ))
+
+    def test_wrong_value(self):
+        self.assertTrue(self.check.check_single(
+            u'{{name}} string',
+            u'{{notname}} string',
+            MockUnit('angularjs_wrong_value'),
+            0
+        ))

--- a/weblate/trans/tests/test_angularjs_checks.py
+++ b/weblate/trans/tests/test_angularjs_checks.py
@@ -36,50 +36,42 @@ class AngularJSInterpolationCheckTest(TestCase):
         self.assertFalse(self.check.check_single(
             'strins',
             'string',
-            MockUnit('angularjs_no_format', flags='angularjs-format'),
-            0
+            MockUnit('angularjs_no_format', flags='angularjs-format')
         ))
 
     def test_format(self):
         self.assertFalse(self.check.check_single(
             u'{{name}} string {{other}}',
             u'{{name}} {{other}} string',
-            MockUnit('angularjs_format', flags='angularjs-format'),
-            0
+            MockUnit('angularjs_format', flags='angularjs-format')
         ))
 
     def test_format_ignore_position(self):
         self.assertFalse(self.check.check_single(
             u'{{name}} string {{other}}',
             u'{{other}} string {{name}}',
-            MockUnit(
-                'angularjs_format_ignore_position',
-                flags='angularjs-format'),
-            0
+            MockUnit('angularjs_format_ignore_position',
+                     flags='angularjs-format')
         ))
 
     def test_different_whitespace(self):
         self.assertFalse(self.check.check_single(
             u'{{ name   }} string',
             u'{{name}} string',
-            MockUnit(
-                'angularjs_different_whitespace',
-                flags='angularjs-format'),
-            0
+            MockUnit('angularjs_different_whitespace',
+                     flags='angularjs-format')
         ))
 
     def test_missing_format(self):
         self.assertTrue(self.check.check_single(
             u'{{name}} string',
             u'string',
-            MockUnit('angularjs_missing_format', flags='angularjs-format'),
-            0
+            MockUnit('angularjs_missing_format', flags='angularjs-format')
         ))
 
     def test_wrong_value(self):
         self.assertTrue(self.check.check_single(
             u'{{name}} string',
             u'{{nameerror}} string',
-            MockUnit('angularjs_wrong_value', flags='angularjs-format'),
-            0
+            MockUnit('angularjs_wrong_value', flags='angularjs-format')
         ))


### PR DESCRIPTION
Adds a check that tries to validate AngularJS interpolation strings like e.g. `"Hello {{username}}"` (see https://docs.angularjs.org/api/ng/service/$interpolate). The check makes sure that any interpolation string used in the source is also used again in the target.

The check is disabled by default and can be added with the `angularjs-format` flag.

I actually found the checks API to be a bit confusing, so I hope I got it right. But this check is working fine for me in production for several months now.