### PR TITLE
fix groupACL locking behavior

### DIFF
--- a/weblate/accounts/auth.py
+++ b/weblate/accounts/auth.py
@@ -20,7 +20,7 @@
 
 import sys
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Permission
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.core.urlresolvers import reverse
@@ -84,12 +84,10 @@ class WeblateUserBackend(ModelBackend):
     def _get_group_permissions(self, user_obj):
         """Wrapper around _get_group_permissions to exclude groupacl
 
-        We don't want these to be applied direclty, they should work
+        We don't want these to be applied directly, they should work
         only using group matching rules."""
-        perms = super(WeblateUserBackend, self)._get_group_permissions(
-            user_obj
-        )
-        return perms.exclude(group__groupacl__pk__gt=0)
+        user_groups = user_obj.groups.filter(groupacl=None)
+        return Permission.objects.filter(group__in=user_groups)
 
     def authenticate(self, username=None, password=None, **kwargs):
         '''


### PR DESCRIPTION
The patch provided in #867 was broken, because it was removing _permissions_ where it should have been removing _groups_. So if an ACL-locked group gave you a permission that you already had from elsewhere, it would get removed too.

I have fixed this and added more tests to check for the desired behavior.

