### PR TITLE
Python 3 compatibility fix

### DIFF
--- a/ci/requirements-scrutinizer.txt
+++ b/ci/requirements-scrutinizer.txt
@@ -1,6 +1,7 @@
 Django>=1.8
 Whoosh>=2.5.2,!=2.6.0
-translate-toolkit>=1.10.0
+translate-toolkit>=1.10.0; python_version < '3.0'
+translate-toolkit>=1.14.0rc1; python_version >= '3.0'
 lxml>=3.1.0
 Pillow
 six>=1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Django>=1.8
 Whoosh>=2.5.2,!=2.6.0
-translate-toolkit>=1.10.0
+translate-toolkit>=1.10.0; python_version < '3.0'
+translate-toolkit>=1.14.0rc1; python_version >= '3.0'
 lxml>=3.1.0
 Pillow
 six>=1.7.0


### PR DESCRIPTION
`translate-toolkit` does not have Python 3 compatibility before [Release Candidate 1.14.0-rc1](https://github.com/translate/translate/releases/tag/1.14.0-rc1)

