### PR TITLE
Python 3 compatibility fix

### DIFF
--- a/ci/requirements-scrutinizer.txt
+++ b/ci/requirements-scrutinizer.txt
@@ -1,6 +1,6 @@
 Django>=1.8
 Whoosh>=2.5.2,!=2.6.0
-translate-toolkit>=1.10.0
+translate-toolkit>=1.14.0rc1
 lxml>=3.1.0
 Pillow
 six>=1.7.0

--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -12,7 +12,7 @@ Python (2.7, 3.4 or newer)
     https://www.python.org/
 Django (>= 1.8)
     https://www.djangoproject.com/
-Translate-toolkit (>= 1.10.0)
+Translate-toolkit (>= 1.14.0)
     http://toolkit.translatehouse.org/
 Six (>= 1.7.0)
     https://pypi.python.org/pypi/six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Django>=1.8
 Whoosh>=2.5.2,!=2.6.0
-translate-toolkit>=1.10.0
+translate-toolkit>=1.10.0; python_version < '3.0'
+translate-toolkit>=1.14.0rc1; python_version >= '3.0'
 lxml>=3.1.0
 Pillow
 six>=1.7.0

--- a/weblate.spec
+++ b/weblate.spec
@@ -30,7 +30,7 @@ BuildRequires:  python-python-social-auth >= 0.2
 BuildRequires:  python-selenium
 BuildRequires:  python-sphinxcontrib-httpdomain
 BuildRequires:  python-whoosh >= 2.5.2
-BuildRequires:  translate-toolkit >= 1.10.0
+BuildRequires:  translate-toolkit >= 1.14.0
 Requires:       apache2-mod_wsgi
 Requires:       cron
 Requires:       git
@@ -42,7 +42,7 @@ Requires:       python-dateutil
 Requires:       python-django-crispy-forms >= 1.4.0
 Requires:       python-python-social-auth >= 0.2
 Requires:       python-whoosh >= 2.5.2
-Requires:       translate-toolkit >= 1.10.0
+Requires:       translate-toolkit >= 1.14.0
 Recommends:     python-MySQL-python
 Recommends:     python-psycopg2
 Recommends:     python-pyuca

--- a/weblate.spec
+++ b/weblate.spec
@@ -30,7 +30,7 @@ BuildRequires:  python-python-social-auth >= 0.2
 BuildRequires:  python-selenium
 BuildRequires:  python-sphinxcontrib-httpdomain
 BuildRequires:  python-whoosh >= 2.5.2
-BuildRequires:  translate-toolkit >= 1.14.0
+BuildRequires:  translate-toolkit >= 1.14.0rc1
 Requires:       apache2-mod_wsgi
 Requires:       cron
 Requires:       git

--- a/weblate.spec
+++ b/weblate.spec
@@ -42,7 +42,7 @@ Requires:       python-dateutil
 Requires:       python-django-crispy-forms >= 1.4.0
 Requires:       python-python-social-auth >= 0.2
 Requires:       python-whoosh >= 2.5.2
-Requires:       translate-toolkit >= 1.14.0
+Requires:       translate-toolkit >= 1.14.0rc1
 Recommends:     python-MySQL-python
 Recommends:     python-psycopg2
 Recommends:     python-pyuca


### PR DESCRIPTION
`translate-toolkit` does not have Python 3 compatibility before [Release Candidate 1.14.0-rc1](https://github.com/translate/translate/releases/tag/1.14.0-rc1)