### PR TITLE
Windows fix for popen and unicode_literals + import_project CLI

### DIFF
--- a/weblate/trans/management/commands/import_project.py
+++ b/weblate/trans/management/commands/import_project.py
@@ -183,7 +183,7 @@ class Command(BaseCommand):
         Returns relative path of matched files.
         '''
         matches = glob(os.path.join(repo, self.filemask))
-        return [f.replace(repo, '').strip('/') for f in matches]
+        return [f.replace(repo, '').replace('\\', '/').strip('/') for f in matches]
 
     def get_matching_subprojects(self, repo):
         '''

--- a/weblate/trans/models/subproject.py
+++ b/weblate/trans/models/subproject.py
@@ -949,10 +949,10 @@ class SubProject(models.Model, PercentMixin, URLMixin, PathMixin):
 
     def get_mask_matches(self):
         """Returns files matching current mask."""
-        prefix = os.path.join(self.get_path(), '')
+        prefix = os.path.join(self.get_path(), '').replace('\\', '/')
         matches = set()
         for filename in glob(os.path.join(self.get_path(), self.filemask)):
-            path = filename.replace(prefix, '')
+            path = filename.replace('\\', '/').replace(prefix, '')
             code = self.get_lang_code(path)
             if re.match(self.language_regex, code):
                 matches.add(path)

--- a/weblate/trans/scripts.py
+++ b/weblate/trans/scripts.py
@@ -68,14 +68,14 @@ def run_hook(component, translation, script, *args):
             target = component.linked_subproject
         else:
             target = component
-        environment['WL_VCS'] = target.vcs
-        environment['WL_REPO'] = target.repo
-        environment['WL_PATH'] = target.get_path()
-        environment['WL_FILEMASK'] = component.filemask
-        environment['WL_TEMPLATE'] = component.template
-        environment['WL_FILE_FORMAT'] = component.file_format
+        environment[str('WL_VCS')] = str(target.vcs)
+        environment[str('WL_REPO')] = str(target.repo)
+        environment[str('WL_PATH')] = str(target.get_path())
+        environment[str('WL_FILEMASK')] = str(component.filemask)
+        environment[str('WL_TEMPLATE')] = str(component.template)
+        environment[str('WL_FILE_FORMAT')] = str(component.file_format)
         if translation:
-            environment['WL_LANGUAGE'] = translation.language_code
+            environment[str('WL_LANGUAGE')] = str(translation.language_code)
         try:
             subprocess.check_call(
                 command,

--- a/weblate/trans/util.py
+++ b/weblate/trans/util.py
@@ -203,15 +203,15 @@ def get_clean_env(extra=None):
     Returns cleaned up environment for subprocess execution.
     """
     environ = {
-        'LANG': 'en_US.UTF-8',
-        'HOME': data_dir('home'),
+        str('LANG'): str('en_US.UTF-8'),
+        str('HOME'): str(data_dir('home')),
     }
     if extra is not None:
         environ.update(extra)
     variables = ('PATH', 'LD_LIBRARY_PATH')
     for var in variables:
         if var in os.environ:
-            environ[var] = os.environ[var]
+            environ[str(var)] = str(os.environ[var])
     return environ
 
 

--- a/weblate/trans/vcs.py
+++ b/weblate/trans/vcs.py
@@ -130,8 +130,8 @@ class Repository(object):
         Resolves any symlinks in the path.
         """
         # Resolve symlinks first
-        real_path = os.path.realpath(os.path.join(self.path, path))
-        repository_path = os.path.realpath(self.path)
+        real_path = os.path.realpath(os.path.join(self.path, path)).replace('\\', '/')
+        repository_path = os.path.realpath(self.path).replace('\\', '/')
 
         if not real_path.startswith(repository_path):
             raise ValueError('Too many symlinks or link outside tree')
@@ -149,7 +149,7 @@ class Repository(object):
         process = subprocess.Popen(
             args,
             cwd=cwd,
-            env=get_clean_env({'GIT_SSH': ssh_file(SSH_WRAPPER)}),
+            env=get_clean_env({str('GIT_SSH'): str(ssh_file(SSH_WRAPPER))}),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )


### PR DESCRIPTION
Fixes subprocess.call() on Windows due to use of future unicode_literals (see https://github.com/nephila/djangocms-installer/pull/228 and https://github.com/nvie/pip-tools/issues/209), when invoking manage.py migrate.

Also fixes `get_matching_files()` in import_project.py with glob.glob() returning paths with forward slashes.

EDIT: squashed two more commits for another glob() and os.path.realpath() calls.
