### PR TITLE
Fix missing typefaces in font-linux.css

### DIFF
--- a/weblate/static/font-linux/font-linux.css
+++ b/weblate/static/font-linux/font-linux.css
@@ -4,9 +4,7 @@
 
 @font-face {
   font-family: "font-linux";
-  src: url("./font-linux.eot");
-  src: url("./font-linux.eot?#iefix") format("embedded-opentype"),
-       url("./font-linux.woff") format("woff"),
+  src: url("./font-linux.woff") format("woff"),
        url("./font-linux.ttf") format("truetype"),
        url("./font-linux.svg#font-linux") format("svg");
   font-weight: normal;


### PR DESCRIPTION
There are no `font-linux.eot` typeface in the repo. While executing `collectstatic` and `compress` this raises an error.

This is a simple fix removing the missing font from the CSS.
