### PR TITLE
Simple health check urls

### DIFF
--- a/weblate/settings_example.py
+++ b/weblate/settings_example.py
@@ -586,6 +586,10 @@ REST_FRAMEWORK = {
     'VIEW_DESCRIPTION_FUNCTION': 'weblate.api.views.get_view_description',
 }
 
+# standard health checks for cluster environments
+HEALTHCHECK_ENABLED = True
+HEALTHCHECK_PATH =  r'^healthz/$'
+
 # Example for restricting access to logged in users
 # LOGIN_REQUIRED_URLS = (
 #     r'/(.*)$',
@@ -598,6 +602,7 @@ REST_FRAMEWORK = {
 #    r'/widgets/(.*)$',  # Allowing public access to widgets
 #    r'/data/(.*)$',     # Allowing public access to data exports
 #    r'/hooks/(.*)$',    # Allowing public access to notification hooks
+#    HEALTHCHECK_PATH,   # Allow for cluster health check
 # )
 
 # Force sane test runner

--- a/weblate/urls.py
+++ b/weblate/urls.py
@@ -845,3 +845,13 @@ if 'weblate.billing' in settings.INSTALLED_APPS:
             name='invoice-download',
         ),
     ]
+
+if getattr(settings, 'HEALTHCHECK_ENABLED', False):
+    from django.http import HttpResponse
+    def _healthz(request):
+        return HttpResponse("ok")
+
+    health_check_path = getattr(settings, "HEALTHCHECK_PATH", r'^healthz/$')
+    urlpatterns += [
+        url(health_check_path, _healthz, name="health_check"),
+    ]


### PR DESCRIPTION
In order to be able to deploy weblate on a kubernetes we needed to add a health check URL.  

This is a simple check and I would love to get some feedback on the style and options.

Please tell me if you prefer to manage this on a issue and latter move it to a pull request.