### PR TITLE
Doc: Add libjpeg as required package for installations using pip

### DIFF
--- a/docs/admin/install.rst
+++ b/docs/admin/install.rst
@@ -197,8 +197,8 @@ Most requirements can be also installed using pip installer:
 
     pip install -r requirements.txt
 
-Also you will need header files for ``python-dev``, ``libxml2``, ``libxslt``
-and ``libfreetype6`` to compile some of the required Python modules.
+Also you will need header files for ``python-dev``, ``libxml2``, ``libxslt``,
+``libjpeg`` and ``libfreetype6`` to compile some of the required Python modules.
 
 All optional dependencies (see above) can be installed using:
 
@@ -210,13 +210,13 @@ On Debian or Ubuntu you can install them using:
 
 .. code-block:: sh
 
-    apt-get install libxml2-dev libxslt-dev libfreetype6-dev python-dev
+    apt-get install libxml2-dev libxslt-dev libfreetype6-dev libjpeg-dev python-dev
 
 On openSUSE or SLES you can install them using:
 
 .. code-block:: sh
 
-    zypper install libxslt-devel libxml2-devel freetype-devel python-devel
+    zypper install libxslt-devel libxml2-devel freetype-devel libjpeg-devel python-devel
 
 .. _install-weblate:
 


### PR DESCRIPTION
On Debian Jessie libjpeg-dev was required to install Pillow (as specified in requirements.txt). I don't have an OpenSUSE box at hand to test whether it is really called libjpeg-devel.