### PR TITLE
Github - Fixes error when forking with multiple subprojects

### DIFF
--- a/weblate/trans/vcs.py
+++ b/weblate/trans/vcs.py
@@ -733,7 +733,7 @@ class GithubRepository(GitRepository):
         on fork and creates pull request against original repository.
         """
         self.fork()
-        fork_branch = '{0}-weblate'.format(self.branch)
+        fork_branch = '{0}-weblate'.format(self.name)
         self.push_to_fork(self.branch, self.branch)
         self.push_to_fork(self.branch, fork_branch)
         try:


### PR DESCRIPTION
### Scenario:
When a project has multiple subprojects (for example, multiple resource files), pushing the second subproject after pushing a first one fails. This happens because the forked branch has the same name for multiple subprojects (every branch is called master-weblate).

### Possible Solution:
These proposal changes makes the branch different for each subpreject, with this name pattern: "subproject-weblate" instead of "master-weblate".

I've tested in our enviroment and it works nicely. I don't know if this is the best solution, but I hope it can at least give a hint for fixing this problem.