### PR TITLE
GroupACL partial match bug

### DIFF
--- a/weblate/trans/permissions.py
+++ b/weblate/trans/permissions.py
@@ -49,9 +49,10 @@ def has_group_perm(user, permission, translation=None, project=None):
     """
     if translation is not None:
         acls = list(GroupACL.objects.filter(
-            Q(language=translation.language) |
-            Q(project=translation.subproject.project) |
-            Q(subproject=translation.subproject)
+            (Q(language=translation.language) | Q(language=None)) &
+            (Q(project=translation.subproject.project) | Q(project=None)) &
+            (Q(subproject=translation.subproject) | Q(subproject=None)) &
+            ~Q(language=None, project=None, subproject=None)
         ))
     elif project is not None:
         acls = list(GroupACL.objects.filter(

--- a/weblate/trans/permissions.py
+++ b/weblate/trans/permissions.py
@@ -52,7 +52,7 @@ def has_group_perm(user, permission, translation=None, project=None):
             (Q(language=translation.language) | Q(language=None)) &
             (Q(project=translation.subproject.project) | Q(project=None)) &
             (Q(subproject=translation.subproject) | Q(subproject=None)) &
-            ~Q(language=None, project=None, subproject=None)
+            (~Q(language=None, project=None, subproject=None))
         ))
     elif project is not None:
         acls = list(GroupACL.objects.filter(

--- a/weblate/trans/tests/test_permissions.py
+++ b/weblate/trans/tests/test_permissions.py
@@ -231,6 +231,35 @@ class GroupACLTest(ModelTestCase):
         self.assertTrue(can_edit(self.privileged, trans_de, self.PERMISSION))
         self.assertTrue(can_edit(self.user, trans_de, self.PERMISSION))
 
+    def test_affects_partial_match(self):
+        '''
+        Partial match test.
+        If I set an ACL on two criteria, e.g., subproject and language,
+        it should not affect objects that only match one of the criteria.
+        '''
+        lang_cs = Language.objects.get(code='cs')
+        lang_de = Language.objects.get(code='de')
+        trans_cs = Translation.objects.create(
+            subproject=self.subproject, language=lang_cs,
+            filename="this/is/not/a.template"
+        )
+        trans_de = Translation.objects.create(
+            subproject=self.subproject, language=lang_de,
+            filename="this/is/not/a.template"
+        )
+
+        acl = GroupACL.objects.create(
+            language=lang_cs,
+            subproject=self.subproject
+        )
+        acl.groups.add(self.group)
+
+        self.assertTrue(can_edit(self.privileged, trans_cs, self.PERMISSION))
+        self.assertFalse(can_edit(self.user, trans_cs, self.PERMISSION))
+
+        self.assertTrue(can_edit(self.privileged, trans_de, self.PERMISSION))
+        self.assertTrue(can_edit(self.user, trans_de, self.PERMISSION))
+
     def clear_permission_cache(self):
         '''
         Clear permission cache.


### PR DESCRIPTION
This is a serious bug in GroupACL code that we discovered when deploying on l10n.opensuse

Basically it boils down to using OR matching instead of, well, more clever matching, for the ACL rules. In effect, a Group ACL set to project+language would affect *all* languages in that project, and the same language in *all* projects. This was not discovered earlier because if a different ACL rule applies to another language, it (correctly) takes precedence and everything looks OK.

This PR contains explanations for current Group ACL tests, a new test for this issue, and a fix for the matching query.